### PR TITLE
Add gulp-plumber to build process

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -16,7 +16,12 @@ var reload 			 = browserSync.reload;
 // Styles - PostCSS, Lost, Rucksack, sourcemaps
 gulp.task('styles', function () {
 	return gulp.src('./src/css/*.css')
-		.pipe(plumber())
+		.pipe(plumber({
+			errorHandler: function (err) {
+				console.log(err);
+				this.emit('end');
+			}
+		}))
 		.pipe(sourcemaps.init())
 		.pipe(postcss([
 			precss(),
@@ -27,7 +32,6 @@ gulp.task('styles', function () {
 			flexboxFixes()
 		]))
 		.pipe(sourcemaps.write())
-		.pipe(plumber.stop())
 		.pipe(gulp.dest('./dist/css'))
 		.pipe(reload({stream: true}));
 });

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -8,6 +8,7 @@ var flexboxFixes = require('postcss-flexbugs-fixes');
 var imagemin		 = require('gulp-imagemin');
 var slim 				 = require('gulp-slim');
 var ghPages 		 = require('gulp-gh-pages');
+var plumber 		 = require('gulp-plumber');
 
 var browserSync  = require('browser-sync');
 var reload 			 = browserSync.reload;
@@ -15,6 +16,7 @@ var reload 			 = browserSync.reload;
 // Styles - PostCSS, Lost, Rucksack, sourcemaps
 gulp.task('styles', function () {
 	return gulp.src('./src/css/*.css')
+		.pipe(plumber())
 		.pipe(sourcemaps.init())
 		.pipe(postcss([
 			precss(),
@@ -25,6 +27,7 @@ gulp.task('styles', function () {
 			flexboxFixes()
 		]))
 		.pipe(sourcemaps.write())
+		.pipe(plumber.stop())
 		.pipe(gulp.dest('./dist/css'))
 		.pipe(reload({stream: true}));
 });

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "gulp": "^3.9.1",
     "gulp-gh-pages": "^0.5.4",
     "gulp-imagemin": "^2.4.0",
+    "gulp-plumber": "^1.1.0",
     "gulp-postcss": "^6.1.0",
     "gulp-slim": "^0.3.0",
     "gulp-sourcemaps": "^1.6.0",

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -7,6 +7,7 @@
 @lost flexbox flex;
 
 body {
+	background-color: blue;
 }
 
 a:visited {

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -7,7 +7,6 @@
 @lost flexbox flex;
 
 body {
-	background-color: blue;
 }
 
 a:visited {


### PR DESCRIPTION
Use gulp-plumber to prevent the gulp task from exiting when it encounters an error in CSS.
